### PR TITLE
port PR rails/rails#7416

### DIFF
--- a/lib/rails/perftest/active_support/testing/performance.rb
+++ b/lib/rails/perftest/active_support/testing/performance.rb
@@ -17,7 +17,7 @@ module ActiveSupport
 
       # each implementation should define metrics and freeze the defaults
       DEFAULTS =
-        if ARGV.include?('--benchmark') # HAX for rake test
+        if ENV["BENCHMARK_TESTS"]
           { :runs => 4,
             :output => 'tmp/performance',
             :benchmark => true }

--- a/lib/rails/perftest/active_support/testing/performance/jruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/jruby.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :user_time, :memory, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/lib/rails/perftest/active_support/testing/performance/rubinius.rb
+++ b/lib/rails/perftest/active_support/testing/performance/rubinius.rb
@@ -4,7 +4,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           {:metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time]}
         else
           { :metrics => [:wall_time],

--- a/lib/rails/perftest/active_support/testing/performance/ruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/ruby.rb
@@ -9,7 +9,7 @@ module ActiveSupport
   module Testing
     module Performance
       DEFAULTS.merge!(
-        if ARGV.include?('--benchmark')
+        if ENV["BENCHMARK_TESTS"]
           { :metrics => [:wall_time, :memory, :objects, :gc_runs, :gc_time] }
         else
           { :min_percent => 0.01,

--- a/lib/rails/perftest/commands/benchmarker.rb
+++ b/lib/rails/perftest/commands/benchmarker.rb
@@ -2,9 +2,9 @@ require 'optparse'
 require 'rails/test_help'
 require 'rails/performance_test_help'
 
-ARGV.push('--benchmark') # HAX
+ENV["BENCHMARK_TESTS"] = '1'
+
 require 'rails/perftest/active_support/testing/performance'
-ARGV.pop
 
 def options
   options = {}

--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -1,8 +1,11 @@
 namespace :test do
-  Rails::SubTestTask.new(benchmark: 'test:prepare') do |t|
+  task 'perftest:benchmark_mode' do
+    ENV["BENCHMARK_TESTS"] = '1'
+  end
+
+  Rails::SubTestTask.new(benchmark: ['test:prepare', 'test:perftest:benchmark_mode']) do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
-    t.options = '-- --benchmark'
   end
 
   Rails::SubTestTask.new(profile: 'test:prepare') do |t|


### PR DESCRIPTION
This is a port of https://github.com/rails/rails/pull/7416. I modified the original implementation because there were two problems:
1. `perftest benchmarker` did not work
2. `rake test:profile` did not work

I solved 1.) by setting the environment variable for the benchmarker command. 2.) was related to the definitions of the rake tasks. They are always executed not only when triggered. This meant that the environment variable was always set. I created a setup task, which is a precondition of `rake test:benchmark` to work around this issue. 
