### PR TITLE
Including rails-perftest gem breaks projects without minitest

### DIFF
--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -1,3 +1,5 @@
+require 'rails/test_unit/sub_test_task' # for SubTestTask in case rails app doesn't require "rails/test_unit/railtie"
+
 namespace :test do
   task 'perftest:benchmark_mode' do
     ENV["BENCHMARK_TESTS"] = '1'


### PR DESCRIPTION
Including this gem on projects using rspec raises uninitialized constant Rails::SubTestTask for rake. This patch fixes that.

Note, to use without mini-test rakerules user have to define `test:prepare` himself and add necessary requires. Something like this could be added to readme for using this with rspec based projects:

```
namespace :test do
  task 'prepare' do
  end
end
```

a testcase could look like this: 
test/performance/performance_test_helper.rb

```
ENV['RAILS_ENV']='test'
require File.expand_path('../../../config/environment', __FILE__)
require 'rails/performance_test_help'

require 'minitest/autorun'
```

testcase:

```
require_relative 'performance_test'
class HelloTest < ActionDispatch::PerformanceTest
  def test_foo
    get "/hello"
  end
end
```
## To reproduce:

```
rails new perftest_test -T
cd perftest_test
bundle exec rake -T
echo "gem 'rails-perftest'" >> Gemfile
bundle install
bundle exec rake -T

NameError: uninitialized constant Rails::SubTestTask
/Users/boga/.rvm/gems/ruby-2.0.0-p451/gems/rails-perftest-0.0.4/lib/rails/perftest/railties/testing.tasks:6:in `block in <top (required)>'
```
