### PR TITLE
Add a fallback from 'test:prepare'

### DIFF
--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -4,14 +4,25 @@ namespace :test do
   task 'perftest:benchmark_mode' do
     ENV["BENCHMARK_TESTS"] = '1'
   end
+  if Rake::Task.task_defined?('test:prepare')
+    Rails::SubTestTask.new(benchmark: ['test:prepare', 'test:perftest:benchmark_mode']) do |t|
+      t.libs << 'test'
+      t.pattern = 'test/performance/**/*_test.rb'
+    end
 
-  Rails::SubTestTask.new(benchmark: ['test:prepare', 'test:perftest:benchmark_mode']) do |t|
-    t.libs << 'test'
-    t.pattern = 'test/performance/**/*_test.rb'
-  end
+    Rails::SubTestTask.new(profile: 'test:prepare') do |t|
+      t.libs << 'test'
+      t.pattern = 'test/performance/**/*_test.rb'
+    end
+  else
+    Rails::SubTestTask.new(benchmark: ['db:test:prepare', 'test:perftest:benchmark_mode']) do |t|
+      t.libs << 'test'
+      t.pattern = 'test/performance/**/*_test.rb'
+    end
 
-  Rails::SubTestTask.new(profile: 'test:prepare') do |t|
-    t.libs << 'test'
-    t.pattern = 'test/performance/**/*_test.rb'
+    Rails::SubTestTask.new(profile: 'db:test:prepare') do |t|
+      t.libs << 'test'
+      t.pattern = 'test/performance/**/*_test.rb'
+    end
   end
 end


### PR DESCRIPTION
These changes fix an issue with rails-perftest as mentioned in issue #24. It checks to see if there is a rake task for 'test:prepare', and if there is it will continue as it would normally. Otherwise it falls back to the 'db:test:prepare' rake task. This passes all of the tests (which need to be improved) and I tested it on a few rails apps, and it worked just fine. Resolves #24.