### PR TITLE
Add generator for test/test_helper.rb

### DIFF
--- a/lib/generators/rails/performance_test/performance_test_generator.rb
+++ b/lib/generators/rails/performance_test/performance_test_generator.rb
@@ -9,6 +9,10 @@ module Rails
         template 'performance_test.rb', File.join('test/performance', class_path, "#{file_name}_test.rb")
       end
 
+      def create_test_helper_file
+        new_filename = File.join('test', 'test_helper.rb')
+        template 'test_helper.rb', new_filename unless File.exist?(new_filename)
+      end
     end
   end
 end

--- a/lib/generators/rails/performance_test/templates/test_helper.rb
+++ b/lib/generators/rails/performance_test/templates/test_helper.rb
@@ -1,0 +1,12 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+require 'rails/test_help'
+
+module ActiveSupport
+  class TestCase
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
+
+    # Add more helper methods to be used by all tests here...
+  end
+end

--- a/test/generators/performance_test_generator_test.rb
+++ b/test/generators/performance_test_generator_test.rb
@@ -14,5 +14,6 @@ class PerformanceTestGeneratorTest < Rails::Generators::TestCase
   def test_performance_test_skeleton_is_created
     run_generator
     assert_file "test/performance/dashboard_test.rb", /class DashboardTest < ActionDispatch::PerformanceTest/
+    assert_file "test/test_helper.rb", /class TestCase/
   end
 end


### PR DESCRIPTION
Add a generator for test/test_helper.rb that only tries to generate the file if it does not already exist.

My project didn't have a test_helper file.  I assumed it was supposed to be from some gem and spent too much time trying to figure out what gem before I realized `rails generate new` was supposed to have created it.

