### PR TITLE
Fix 'wrong number of arguments' error from ruby-prof

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    ruby-prof (0.15.7)
+    ruby-prof (0.16.2)
     sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -92,5 +92,8 @@ DEPENDENCIES
   minitest (>= 3)
   rails-perftest!
   railties (~> 4.0)
-  ruby-prof (>= 0.12.1)
+  ruby-prof (>= 0.16.2)
   sqlite3 (~> 1.3)
+
+BUNDLED WITH
+   1.13.7

--- a/lib/rails/perftest/active_support/testing/performance/ruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/ruby.rb
@@ -49,9 +49,15 @@ module ActiveSupport
 
           klasses.each do |klass|
             fname = output_filename(klass)
-            FileUtils.mkdir_p(File.dirname(fname))
-            File.open(fname, 'wb') do |file|
-              klass.new(@data).print(file, full_profile_options.slice(:min_percent))
+            printer = klass.new(@data)
+            if printer.is_a?(RubyProf::CallTreePrinter)
+              FileUtils.mkdir_p(fname)
+              printer.print(full_profile_options.merge(path: fname))
+            else
+              FileUtils.mkdir_p(File.dirname(fname))
+              File.open(fname, 'wb') do |file|
+                printer.print(file, full_profile_options.slice(:min_percent))
+              end
             end
           end
         end
@@ -65,7 +71,7 @@ module ActiveSupport
                 when 'GraphPrinter';                'graph.txt'
                 when 'GraphHtmlPrinter';            'graph.html'
                 when 'GraphYamlPrinter';            'graph.yml'
-                when 'CallTreePrinter';             'tree.txt'
+                when 'CallTreePrinter';             'tree'
                 when 'CallStackPrinter';            'stack.html'
                 when 'DotPrinter';                  'graph.dot'
                 else printer_class.name.sub(/Printer$/, '').underscore

--- a/rails-perftest.gemspec
+++ b/rails-perftest.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Rails::Perftest::VERSION
 
-  gem.add_development_dependency 'ruby-prof', '>= 0.12.1'
+  gem.add_development_dependency 'ruby-prof', '>= 0.16.2'
   gem.add_development_dependency 'minitest', '>= 3'
   gem.add_development_dependency 'railties', '~> 4.0'
   gem.add_development_dependency 'activerecord', '~> 4.0'


### PR DESCRIPTION
Fix the below error by changing the way we call RubyProf::CallTreePrinter#print:
> gems/ruby-prof-0.16.2/lib/ruby-prof/printers/call_tree_printer.rb:46:in `print': wrong number of arguments (given 2, expected 0..1) (ArgumentError)

The ruby-prof gem's RubyProf::CallTreePrinter#print API was changed in a non-backwords compatible way in https://github.com/ruby-prof/ruby-prof/commit/24a267bc7b50dc743930945acdaccfdca2417e94