### PR TITLE
Handle absense of rake db:test:prepare / test:prepare on recent Rails versions

### DIFF
--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -5,12 +5,17 @@ namespace :test do
     ENV["BENCHMARK_TESTS"] = '1'
   end
 
-  Rake::TestTask.new(benchmark: ['test:prepare', 'test:perftest:benchmark_mode']) do |t|
+  requirements = []
+  if Rake::Task.task_defined?('db:test:prepare')
+    requirements << 'db:test:prepare'
+  end
+
+  Rake::TestTask.new(benchmark: requirements + ['test:perftest:benchmark_mode']) do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
   end
 
-  Rake::TestTask.new(profile: 'test:prepare') do |t|
+  Rake::TestTask.new(profile: requirements) do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
   end

--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -12,11 +12,13 @@ namespace :test do
 
   Rake::TestTask.new(benchmark: requirements + ['test:perftest:benchmark_mode']) do |t|
     t.libs << 'test'
+    t.warning = false
     t.pattern = 'test/performance/**/*_test.rb'
   end
 
   Rake::TestTask.new(profile: requirements) do |t|
     t.libs << 'test'
+    t.warning = false
     t.pattern = 'test/performance/**/*_test.rb'
   end
 end


### PR DESCRIPTION
This change should be backward-compatible with previous Rails versions.

Rails 4+ is deprecating `db:test:prepare` since it is now handled tranparently by Rails itself.