### PR TITLE
(Duplicate) Fix 'wrong number of arguments' error from ruby-prof 

### DIFF
--- a/lib/rails/perftest/active_support/testing/performance/ruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/ruby.rb
@@ -50,8 +50,14 @@ module ActiveSupport
           klasses.each do |klass|
             fname = output_filename(klass)
             FileUtils.mkdir_p(File.dirname(fname))
-            File.open(fname, 'wb') do |file|
-              klass.new(@data).print(file, full_profile_options.slice(:min_percent))
+
+            printer = klass.new(@data)
+            if printer.is_a?(RubyProf::CallTreePrinter)
+              printer.print(full_profile_options.merge(path: File.dirname(fname)))
+            else
+              File.open(fname, 'wb') do |file|
+                printer.print(file, full_profile_options.slice(:min_percent))
+              end
             end
           end
         end


### PR DESCRIPTION
This is a duplicate, aiming at solving the same issue of https://github.com/rails/rails-perftest/pull/42.

(only reason why I'm duplicating this is because I had to reproduce the fix to use the gem, and identified that https://github.com/rails/rails-perftest/pull/42 had an implementation issue and was conflicting with the master branch... just trying to save ppl some time, the solution is credited to @gabrielmdeal )