### PR TITLE
Change the call to RubyProf::CallTreePrinter#print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ rvm:
 gemfile:
   - gemfiles/Gemfile-rails-4.0
   - gemfiles/Gemfile-rails-4.1
+  - gemfiles/Gemfile-ruby-prof-lt0.16
+
   - Gemfile

--- a/gemfiles/Gemfile-ruby-prof-lt0.16
+++ b/gemfiles/Gemfile-ruby-prof-lt0.16
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'ruby-prof', '< 0.16'
+
+gemspec path: '..'

--- a/lib/rails/perftest/active_support/testing/performance/ruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/ruby.rb
@@ -49,9 +49,18 @@ module ActiveSupport
 
           klasses.each do |klass|
             fname = output_filename(klass)
-            FileUtils.mkdir_p(File.dirname(fname))
-            File.open(fname, 'wb') do |file|
-              klass.new(@data).print(file, full_profile_options.slice(:min_percent))
+            printer = klass.new(@data)
+            options = full_profile_options.slice(:min_percent)
+            path = File.dirname(fname)
+            FileUtils.mkdir_p(path)
+            if printer.is_a?(RubyProf::CallTreePrinter) && RubyProf::VERSION >= "0.16"
+              printer.print(options.merge(:path => path))
+              call_grind_file = Dir.glob("#{path}/*callgrind.out*").first
+              File.rename(call_grind_file, fname)
+            else
+              File.open(fname, 'wb') do |file|
+                printer.print(file, options)
+              end
             end
           end
         end


### PR DESCRIPTION
# What is that about ❓ 

Addresses #38.

## Details

The interface was changed by: https://github.com/ruby-prof/ruby-prof/commit/24a267bc7b50dc743930945acdaccfdca2417e94
This is a quick fix to address just this change.
If those keep arriving maybe would be better to map printer types to
their `#print` interface.