### PR TITLE
Suppress Warnings in Rake Tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/rails/perftest/railties/testing.tasks
+++ b/lib/rails/perftest/railties/testing.tasks
@@ -8,10 +8,12 @@ namespace :test do
   Rake::TestTask.new(benchmark: ['test:prepare', 'test:perftest:benchmark_mode']) do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
+    t.warning = false
   end
 
   Rake::TestTask.new(profile: 'test:prepare') do |t|
     t.libs << 'test'
     t.pattern = 'test/performance/**/*_test.rb'
+    t.warning = false
   end
 end


### PR DESCRIPTION
Rake has a lovely default where `t.warning = true`, but this is highly
annoying if you depend on gems that throw a bunch of warnings. Default
this to `false` so the actual results can be seen.