### PR TITLE
Support Rails 7 in performance_test_help.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ tests will set the following configuration parameters:
 
 ```bash
 ActionController::Base.perform_caching = true
-ActiveSupport::Dependencies.mechanism = :require
+ActiveSupport::Dependencies.mechanism = :require if ActiveSupport::Dependencies.respond_to?(:mechanism=)
 Rails.logger.level = ActiveSupport::Logger::INFO
 ```
 

--- a/lib/rails/performance_test_help.rb
+++ b/lib/rails/performance_test_help.rb
@@ -1,3 +1,3 @@
 ActionController::Base.perform_caching = true
-ActiveSupport::Dependencies.mechanism = :require
+ActiveSupport::Dependencies.mechanism = :require if ActiveSupport::Dependencies.respond_to?(:mechanism=)
 Rails.logger.level = ActiveSupport::Logger::INFO


### PR DESCRIPTION
Rails 7 has removed the ability to configure the mechanism used for
autoloading.