### PR TITLE
update to use ruby-profy > 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    ruby-prof (0.15.7)
+    ruby-prof (1.4.3)
     sqlite3 (1.3.10)
     strscan (3.0.1)
     thor (1.2.1)
@@ -116,7 +116,7 @@ DEPENDENCIES
   minitest (>= 3)
   rails-perftest!
   railties (>= 5.2)
-  ruby-prof (>= 0.12.1)
+  ruby-prof (>= 1.0.0)
   sqlite3 (>= 1.3)
 
 BUNDLED WITH

--- a/lib/rails/perftest/active_support/testing/performance/ruby.rb
+++ b/lib/rails/perftest/active_support/testing/performance/ruby.rb
@@ -113,7 +113,8 @@ module ActiveSupport
           Mode = RubyProf::PROCESS_TIME if RubyProf.const_defined?(:PROCESS_TIME)
 
           def measure
-            RubyProf.measure_process_time
+            RubyProf.measure_mode = Mode
+            super
           end
         end
 
@@ -121,15 +122,18 @@ module ActiveSupport
           Mode = RubyProf::WALL_TIME if RubyProf.const_defined?(:WALL_TIME)
 
           def measure
-            RubyProf.measure_wall_time
+            RubyProf.measure_mode = Mode
+            super
           end
         end
 
         class CpuTime < Time
-          Mode = RubyProf::CPU_TIME if RubyProf.const_defined?(:CPU_TIME)
+          # from ruby-prof changelog: 'Remove the CPU_TIME measurement mode since it duplicates the PROCESS_TIME mode and required inline assembly code'
+          Mode = RubyProf::PROCESS_TIME if RubyProf.const_defined?(:PROCESS_TIME)
 
           def measure
-            RubyProf.measure_cpu_time
+            RubyProf.measure_mode = Mode
+            super
           end
         end
 
@@ -139,6 +143,7 @@ module ActiveSupport
           # Ruby 1.9 + GCdata patch
           if GC.respond_to?(:malloc_allocated_size)
             def measure
+              RubyProf.measure_mode = Mode
               GC.malloc_allocated_size
             end
           end

--- a/rails-perftest.gemspec
+++ b/rails-perftest.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'activerecord', '>= 5.2'
   gem.add_development_dependency 'minitest', '>= 3'
   gem.add_development_dependency 'railties', '>= 5.2'
-  gem.add_development_dependency 'ruby-prof', '>= 0.12.1'
+  gem.add_development_dependency 'ruby-prof', '>= 1.0.0'
   gem.add_development_dependency 'sqlite3', '>= 1.3'
 end

--- a/rails-perftest.gemspec.erb
+++ b/rails-perftest.gemspec.erb
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Rails::Perftest::VERSION
 
-  gem.add_development_dependency 'ruby-prof', '>= 0.12.1'
+  gem.add_development_dependency 'ruby-prof', '>= 1.0.0'
   gem.add_development_dependency 'minitest', '>= 3'
   gem.add_development_dependency 'railties', '~> 4.0'
   gem.add_development_dependency 'activerecord', '~> 4.0'


### PR DESCRIPTION
Fixes #54 by forcing ruby-prof to be greater than 1.0.0.

I tracked the break to this commit https://github.com/ruby-prof/ruby-prof/commit/e39b571000dae9140a2790dd399b5f76113eca5f that removed these deprecated methods in 1.0.0 and beyond.


If you'd prefer to just stick with ruby-prof 0.18.0, I have that change as well.  I left this to be editable by maintainers, so feel free to update as you see fit or request changes from me.